### PR TITLE
Use named parameter when fetching older than notifications

### DIFF
--- a/lib/Db/NotificationTrackerMapper.php
+++ b/lib/Db/NotificationTrackerMapper.php
@@ -61,21 +61,17 @@ class NotificationTrackerMapper extends QBMapper {
 	/**
 	 * @param \DateTimeInterface $date
 	 * @return NotificationTracker[]
+	 * @throws \OCP\DB\Exception
 	 */
 	public function findAllOlderThan(\DateTimeInterface $date, int $limit): array {
 		$qb = $this->db->getQueryBuilder();
 
-		try {
-			$qb->select('*')
-				->from($this->getTableName())
-				->where(
-					$qb->expr()->gt('lastSendNotification', $date->getTimestamp())
-				)
-				->setMaxResults($limit);
-		} catch (\Exception $e) {
-			echo 'rerre';
-		}
-
+		$qb->select('*')
+			->from($this->getTableName())
+			->where(
+				$qb->expr()->gt('lastSendNotification', $this->createNamedParameter($date->getTimestamp()))
+			)
+			->setMaxResults($limit);
 		return $this->findEntities($qb);
 	}
 }


### PR DESCRIPTION
- Make sure that the timestamp is properly set in the query
- Do not catch the exception in the mapper as the service is already handling that: https://github.com/nextcloud/monthly_status_email/blob/61338a7136e1fce17cc7474742a284e4b65358a5/lib/Service/NotificationTrackerService.php#L138