### PR TITLE
Fix unique constrains

### DIFF
--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -1,0 +1,36 @@
+name: Static analysis
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+      - stable*
+
+jobs:
+  static-psalm-analysis:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        ocp-version: [ 'dev-master' ]
+
+    name: Nextcloud ${{ matrix.ocp-version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@master
+
+      - name: Set up php
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 7.4
+          coverage: none
+
+      - name: Install dependencies
+        run: composer i
+
+      - name: Install dependencies
+        run: composer require --dev christophwurst/nextcloud:${{ matrix.ocp-version }}
+
+      - name: Run coding standards check
+        run: composer run psalm

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -5,7 +5,7 @@
     <name>Monthly Status Email</name>
     <summary>Monthly notifications with storage usage and tips and tricks</summary>
     <description>Monthly notifications with some storage usage information and tips and tricks.</description>
-    <version>1.0.7</version>
+    <version>1.0.8</version>
     <licence>agpl</licence>
     <author>Carl Schwan</author>
     <namespace>MonthlyStatusEmail</namespace>

--- a/lib/Migration/Version23000Date2022022912000001.php
+++ b/lib/Migration/Version23000Date2022022912000001.php
@@ -1,0 +1,90 @@
+<?php
+
+/**
+ * @copyright Copyright (c) 2021 Carl Schwan <carl@carlschwan.eu>
+ *
+ * @author Carl Schwan <carl@carlschwan.eu>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+declare(strict_types=1);
+
+namespace OCA\MonthlyStatusEmail\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\Migration\SimpleMigrationStep;
+use OCP\Migration\IOutput;
+use OCP\IDBConnection;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+
+class Version23000Date2022022912000001 extends SimpleMigrationStep {
+
+	/** @var IDBConnection */
+	protected $connection;
+
+	public function __construct(IDBConnection $connection) {
+		$this->connection = $connection;
+	}
+
+	public function preSchemaChange(IOutput $output, Closure $schemaClosure, array $options) {
+		$query = $this->connection->getQueryBuilder();
+
+		// delete all but one entries for each user_id
+		$query->select($query->func()->max('id', 'newest_entry'), 'user_id')
+			->from('notification_tracker')
+			->groupBy('user_id');
+
+		$result = $query->executeQuery();
+		$rows = $result->fetchAll();
+		$result->closeCursor();
+
+		$delete = $this->connection->getQueryBuilder();
+		$delete->delete('notification_tracker')
+			->where($delete->expr()->eq('user_id', $delete->createParameter('user_id')))
+			->andWhere($delete->expr()->neq('id', $delete->createParameter('id')));
+
+		foreach ($rows as $row) {
+			$delete->setParameter('user_id', $row['user_id'], IQueryBuilder::PARAM_STR)
+				->setParameter('id', $row['newest_entry'], IQueryBuilder::PARAM_INT);
+			$delete->executeStatement();
+		}
+	}
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 * @return null|ISchemaWrapper
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options) {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		$table = $schema->getTable('notification_tracker');
+		foreach ($table->getIndexes() as $index) {
+			if ($index->spansColumns(['user_id', 'secret_token'])) {
+				$table->dropIndex($index->getName());
+			}
+		}
+		$table->addUniqueIndex(['user_id']);
+		$table->addUniqueIndex(['secret_token']);
+
+		return $schema;
+	}
+}

--- a/tests/psalm-baseline.xml
+++ b/tests/psalm-baseline.xml
@@ -42,11 +42,4 @@
       <code>\OC_Util</code>
     </UndefinedClass>
   </file>
-  <file src="vendor/phpunit/phpunit/src/Framework/MockObject/Builder/ParametersMatch.php">
-    <ParseError occurrences="3">
-      <code>;</code>
-      <code>;</code>
-      <code>Match</code>
-    </ParseError>
-  </file>
 </files>


### PR DESCRIPTION
This fix an issue where the unique index created was for a pair of <userId, token> instead of having a unique index on the userId and a unique index on the token.

If there are more than one entry with the same userId, we delete the other one. It's safe because we need at most one and the other one will just generate additional noice.

Signed-off-by: Carl Schwan <carl@carlschwan.eu>